### PR TITLE
[FIXED] 'next' action triggered too soon, causing DataWriters to uninitialise prematurely

### DIFF
--- a/src/main/scala/com/github/mnogu/gatling/mqtt/action/MqttRequestAction.scala
+++ b/src/main/scala/com/github/mnogu/gatling/mqtt/action/MqttRequestAction.scala
@@ -240,11 +240,12 @@ class MqttRequestAction(
               if (isSuccess) OK else KO,
               message)
 
+            next ! session
+
             connection.disconnect(null)
           }
         })
 
-      next ! session
     }
   }
 }


### PR DESCRIPTION
Fixes "DataWriters haven't been initialised" error. Occurs because DataWriters uninitialise themselves as a result of the final `next ! session` call, but a `DataWriter.dispatch` call is still pending for the final mqtt callback.
