### PR TITLE
Set the SBT version

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.17


### PR DESCRIPTION
When no explicit version is defined, SBT tries to load this project using SBT 1.0, which fails.